### PR TITLE
moved sidebarbutton in sidebar when it is open

### DIFF
--- a/src/lib/components/app-sidebar.svelte
+++ b/src/lib/components/app-sidebar.svelte
@@ -38,6 +38,9 @@
     <Sidebar.Root>
         <Sidebar.Content>
             <Sidebar.Group>
+                <div class="flex justify-end p-2">
+                    <Sidebar.Trigger />
+                </div>
                 <Sidebar.Menu>
                     {#each items as item (item.title)}
                         <Sidebar.MenuItem>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,13 +5,16 @@
     import AppSidebar from "$lib/components/app-sidebar.svelte";
 
     let { children } = $props();
+    let open = $state(true);
 </script>
 
 <UserNav />
-<Sidebar.Provider>
+<Sidebar.Provider bind:open>
     <AppSidebar />
     <main class="flex-1 h-full">
-        <Sidebar.Trigger />
+        {#if !open}
+            <Sidebar.Trigger />
+        {/if}
         {@render children?.()}
     </main>
 </Sidebar.Provider>


### PR DESCRIPTION
## What does this PR do?
Moved the  Sidebar.trigger button into the Sidebar when Sidebar is open. 
Added a check if Sidebar is open or not to show and hide Sidebar.trigger button in layout.svelte file.

### Related Issues & PRs


#### Key Decisions
- **Implemeneted Approach**:
  I have observed other sites which has sidebar (for example: chatGPT) and all are having menu button inside when sidebar is open. 
- **Alternatives Considered**:
  Generally it works like this in other websites and can't think of any alternative. 
- **Rationale**:
  Following standard websites

## Breaking Changes
- [ ] This PR includes breaking changes
  No breaking changes.

### Limitations & Concerns
- **Known limitations**:
- **Edge cases**:
- **Potential risks**:

---

### UI Changes
- [x] This PR includes UI changes

### Screenshots
| Description | Screenshot |
|-------------|------------|

https://github.com/user-attachments/assets/a01d0f4a-e326-40c9-806d-4c99ed94c617


---

### Reviewers
<!-- Tag at least 2 others for review -->
- [ ] Reviewer 1: @rupalirajput2597 
- [ ] Reviewer 2: @RaghvindYadav 
- [x] Reviewer 3: @jonahtwalker 

### Next Steps
NA

### How to Test
1. Prerequisites:
2. Test steps:
3. Expected results:
   When Sidebar window is open the Trigger button should be inside the window.

## Final Checklist
- [ ] Linked related issues
- [ ] Rebased with target branch
- [ ] No lint errors
- [ ] QA'd in multiple browsers
- [ ] Added/updated tests (if applicable)
- [ ] Mobile responsive (if applicable)
- [ ] Updated documentation (if applicable)
- [ ] Notified the Team of this updates readiness

---

## AI Usage
<!-- Document any AI tools you used to develop this -->
- [ ] AI tools were used in development
  - **Tool used**:
   Augment Code
  - **Prompts used**:
  -  - **Initial prompt**: 
  -  Please add the code to check if Sidebar is open or not in svelte5
  - align <Sidebar.Trigger /> to top right corner in the  app-sidebar.svelte file
   

## References
- **Documentation**:
- **Discussions**:
- **Related PRs**:
