### PR TITLE
Use node version from .nvmrc in testing workflow

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: ".nvmrc"
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: ".nvmrc"
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
Really simple PR, just updated the workflow yml to use the node version in `.nvmrc`