### PR TITLE
Es/e2e test fix

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Run unit tests
         run: pnpm run test:unit:ci
 
-  integration-tests:
-    name: Run Integration Tests
+  e2e-tests:
+    name: Run E2E Tests
     runs-on: ubuntu-latest
     needs: unit-tests # Runs only if unit tests pass
     env:

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "globals": "^15.14.0",
     "jsdom": "^26.0.0",
     "lucide-svelte": "^0.475.0",
-    "playwright": "^1.51.1",
     "prettier": "^3.4.2",
     "prettier-plugin-organize-imports": "^4.1.0",
     "prettier-plugin-svelte": "^3.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,9 +126,6 @@ importers:
       lucide-svelte:
         specifier: ^0.475.0
         version: 0.475.0(svelte@5.22.6)
-      playwright:
-        specifier: ^1.51.1
-        version: 1.51.1
       prettier:
         specifier: ^3.4.2
         version: 3.5.3
@@ -7059,7 +7056,8 @@ snapshots:
 
   playwright-core@1.51.0: {}
 
-  playwright-core@1.51.1: {}
+  playwright-core@1.51.1:
+    optional: true
 
   playwright@1.51.0:
     dependencies:
@@ -7072,6 +7070,7 @@ snapshots:
       playwright-core: 1.51.1
     optionalDependencies:
       fsevents: 2.3.2
+    optional: true
 
   polished@4.3.1:
     dependencies:

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -12,8 +12,8 @@ test('Landing page has welcome text, Get Started Button', async ({ page }) => {
   await expect(subtextElement).toBeVisible();
 
   // Check for the Get Started button
-  const logInButton = page.getByRole('button', { name: 'Get Started' });
-  await expect(logInButton).toBeVisible();
+  const getStartedButton = page.getByText('Get Started');
+  await expect(getStartedButton).toBeVisible();
 });
 
 test('Landing page includes NavBar component, signup, login buttons', async ({ page }) => {
@@ -22,18 +22,23 @@ test('Landing page includes NavBar component, signup, login buttons', async ({ p
   // Check for the navigation bar
   // Since the NavBar is in the layout, we can verify it by checking for elements that are part of the NavBar
   //const navElement = page.locator('nav');
-  const navElement = page.getByRole('navigation').filter({ hasText: 'Log In Sign Up Open Menu' });
+  const navElement = page.getByRole('navigation').filter({ hasText: 'Sign In Sign Up' });
   await expect(navElement).toBeVisible();
 
   // We can also check for specific elements within the NavBar
-  const themeToggleButton = page.getByRole('button', { name: /toggle theme/i });
+  // Check if it contains a toggle theme button
+  const themeToggleButton = navElement.getByRole('button', { name: 'Toggle theme' });
   await expect(themeToggleButton).toBeVisible();
 
-  // Check if it contains a Sign Up button
-  const signUpButton = navElement.getByText('Sign Up');
-  await expect(signUpButton).toBeVisible();
+  // Check if it contains a change language button
+  const changeLanguageButton = navElement.getByRole('button', { name: 'Change language' });
+  await expect(changeLanguageButton).toBeVisible();
 
-  // Check if it contains a Log In button
-  const logInButton = navElement.getByText('Log In');
-  await expect(logInButton).toBeVisible();
+  // Check if it contains a "Sign In" button
+  const signInButton = navElement.getByRole('button', { name: 'Sign In' });
+  await expect(signInButton).toBeVisible();
+
+  // Check if it contains a "Sign Up" button
+  const signUpButton = navElement.getByRole('button', { name: 'Sign Up' });
+  await expect(signUpButton).toBeVisible();
 });

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -21,7 +21,6 @@ test('Landing page includes NavBar component, signup, login buttons', async ({ p
 
   // Check for the navigation bar
   // Since the NavBar is in the layout, we can verify it by checking for elements that are part of the NavBar
-  //const navElement = page.locator('nav');
   const navElement = page.getByRole('navigation').filter({ hasText: 'Sign In Sign Up' });
   await expect(navElement).toBeVisible();
 


### PR DESCRIPTION
Fixes E2E testing:

- Removed `"playwright": "^1.51.1"` from `package.json` since `"@playwright/test": "^1.50.1"` is already included and has `playwright` as a dependency. The version mismatch also caused the following error when running locally:

  ```
  Error: Playwright Test did not expect test() to be called here.
  Most common reasons include:
  - You are calling test() in a configuration file.
  - You are calling test() in a file that is imported by the configuration file.
  - You have two different versions of @playwright/test. This usually happens
    when one of the dependencies in your package.json depends on @playwright/test.
  ```

- Refactored "Integration test" to "E2E test" since playwright does E2E tests.
- Update `landing.spec.ts` to correctly find and test elements.