### PR TITLE
improvement

### DIFF
--- a/src/lib/components/forms/form-ident-input.svelte
+++ b/src/lib/components/forms/form-ident-input.svelte
@@ -25,12 +25,12 @@
   <Form.Control>
     {#snippet children({ props })}
       <Form.Label>{label}</Form.Label>
-      <Input 
-        {...props} 
-        bind:value={$formData[fieldName]} 
+      <Input
+        {...props}
+        bind:value={$formData[fieldName]}
         class={$errors[fieldName] ? 'border-red-500 focus-visible:ring-red-500' : ''}
-        {placeholder} 
-        {disabled} 
+        {placeholder}
+        {disabled}
       />
     {/snippet}
   </Form.Control>

--- a/src/lib/components/forms/form-otp-input.svelte
+++ b/src/lib/components/forms/form-otp-input.svelte
@@ -46,17 +46,14 @@
   <Form.Control>
     {#snippet children({ props })}
       <Form.Label>{label}</Form.Label>
-      <InputOTP.Root 
-        {...props} 
-        {id} 
-        {pattern}
-        maxlength={length} 
-        bind:value={$formData[fieldName]} 
-        >
+      <InputOTP.Root {...props} {id} {pattern} maxlength={length} bind:value={$formData[fieldName]}>
         {#snippet children({ cells })}
           <InputOTP.Group class="w-full">
             {#each cells as cell}
-              <InputOTP.Slot {cell} class={$errors[fieldName] ? 'border-red-500 focus-visible:ring-red-500' : ''}/>
+              <InputOTP.Slot
+                {cell}
+                class={$errors[fieldName] ? 'border-red-500 focus-visible:ring-red-500' : ''}
+              />
             {/each}
           </InputOTP.Group>
         {/snippet}

--- a/src/lib/contexts/msa-listener-handler.svelte.ts
+++ b/src/lib/contexts/msa-listener-handler.svelte.ts
@@ -1,6 +1,11 @@
-import translate from "@/helpers/language/translate";
-import { AppUiMessage, MsaTokenStatus } from "@/types/enums";
-import { type QueryResult, type MultiStepActionProgressResult, MultiStepActionEventType, type SidMultiStepActionProgress } from "@baragaun/bg-node-client";
+import translate from '@/helpers/language/translate';
+import { AppUiMessage, MsaTokenStatus } from '@/types/enums';
+import {
+  MultiStepActionEventType,
+  type MultiStepActionProgressResult,
+  type QueryResult,
+  type SidMultiStepActionProgress,
+} from '@baragaun/bg-node-client';
 
 export class MsaListenerHandler {
   tokenStatus = $state(MsaTokenStatus.unset);
@@ -12,17 +17,17 @@ export class MsaListenerHandler {
   constructor(
     private listenerId: string,
     private response: QueryResult<MultiStepActionProgressResult>,
-    private onSuccess?: () => void
+    private onSuccess?: () => void,
   ) {
     this.initialize();
   }
 
   private initialize(): void {
     if (!this.response.object || !this.response.object.run) {
-      this.errorMessage = 'Missing response object'
-      console.error('myUserContext.addMsaListenerHandler: error: ', this.errorMessage)
+      this.errorMessage = 'Missing response object';
+      console.error('myUserContext.addMsaListenerHandler: error: ', this.errorMessage);
       return;
-    };
+    }
 
     try {
       this.listenerRef = this.response.object.run.addListener({
@@ -35,8 +40,8 @@ export class MsaListenerHandler {
             // The notification failed to go out.
             if (import.meta.env.VITE_APP_ENVIRONMENT === 'development') {
               // We can ignore the failure to send the email in development.
-              console.log('DEVELOPMENT')
-              this.errorMessage = translate(AppUiMessage.msaTokenFailedToSend, AppUiMessage.systemError)
+              console.log('DEVELOPMENT');
+              this.message = translate(AppUiMessage.msaTokenSent);
               return;
             }
             console.error(
@@ -45,7 +50,10 @@ export class MsaListenerHandler {
             );
 
             this.tokenStatus = MsaTokenStatus.sendingFailed;
-            this.errorMessage = translate(AppUiMessage.msaTokenFailedToSend, AppUiMessage.systemError);
+            this.errorMessage = translate(
+              AppUiMessage.msaTokenFailedToSend,
+              AppUiMessage.systemError,
+            );
             return;
           }
 
@@ -76,51 +84,81 @@ export class MsaListenerHandler {
               action.notificationResult,
             );
             this.tokenStatus = MsaTokenStatus.sendingFailed;
-            this.errorMessage = translate(AppUiMessage.msaTokenFailedToSend, AppUiMessage.systemError);
+            this.errorMessage = translate(
+              AppUiMessage.msaTokenFailedToSend,
+              AppUiMessage.systemError,
+            );
             return;
           }
 
           if (eventType === MultiStepActionEventType.failed) {
-            console.error(`${this.listenerId}.multiStepActionListener: error.`, action.notificationResult);
+            console.error(
+              `${this.listenerId}.multiStepActionListener: error.`,
+              action.notificationResult,
+            );
             this.tokenStatus = MsaTokenStatus.verificationFailed;
-            this.errorMessage = translate(AppUiMessage.msaTokenFailedToSend, AppUiMessage.systemError);
+            this.errorMessage = translate(
+              AppUiMessage.msaTokenFailedToSend,
+              AppUiMessage.systemError,
+            );
             return;
           }
 
           if (eventType === MultiStepActionEventType.success) {
             // The token was accepted. The user is now signed in.
-            console.log(`${this.listenerId}.multiStepActionListener: success.`, action.notificationResult);
+            console.log(
+              `${this.listenerId}.multiStepActionListener: success.`,
+              action.notificationResult,
+            );
             this.tokenStatus = MsaTokenStatus.success;
             this.message = translate(AppUiMessage.msaTokenSuccess);
-            
+
             // Proceed with any callback
             if (this.onSuccess) this.onSuccess();
           }
         },
-    });
-  } catch (error) {
-    console.error(`${this.listenerId}.addMsaListener:`, { error });
-    this.tokenStatus = MsaTokenStatus.verificationFailed;
-    this.errorMessage = translate(AppUiMessage.systemError);
-  } finally {
-    this.listening = false;
-  }
-  return;
-};
-
-removeListener(): void {
-  console.log(`Trying to remove this listener: ${this.listenerId}`);
-  try {
-    if (this.listening && this.listenerRef && this.response.object?.run) {
-      this.response.object.run.abort();
-      this.response.object.run.removeListener(this.listenerRef);
-      console.log(`Removed listener for ${this.listenerId}`);
+      });
+    } catch (error) {
+      console.error(`${this.listenerId}.addMsaListener:`, { error });
+      this.tokenStatus = MsaTokenStatus.verificationFailed;
+      this.errorMessage = translate(AppUiMessage.systemError);
+    } finally {
+      this.listening = false;
     }
-  } catch (error) {
-    console.error(`Error removing listener for ${this.listenerId}:`, error);
-  } finally {
-    this.listening = false;
-    this.listenerRef = '';
+    return;
   }
-}
+
+  removeListener(): void {
+    console.log(`Trying to remove this listener: ${this.listenerId}`);
+
+    try {
+      if (this.listenerRef && this.response.object?.run) {
+        // Log the listener reference to verify it exists
+        console.log(`Removing listener with ref: ${this.listenerRef}`);
+
+        // First abort the run if it's still active
+        if (this.response.object.run.abort) {
+          this.response.object.run.abort();
+        }
+
+        // Then remove the listener
+        if (this.response.object.run.removeListener) {
+          this.response.object.run.removeListener(this.listenerRef);
+          console.log(`Successfully removed listener for ${this.listenerId}`);
+        } else {
+          console.error(`removeListener method not found on run object for ${this.listenerId}`);
+        }
+      } else {
+        console.warn(
+          `Cannot remove listener for ${this.listenerId}: listenerRef=${this.listenerRef}, run=${!!this.response.object?.run}`,
+        );
+      }
+    } catch (error) {
+      console.error(`Error removing listener for ${this.listenerId}:`, error);
+    } finally {
+      // Always mark as not listening and clear the reference
+      this.listening = false;
+      this.listenerRef = '';
+    }
+  }
 }

--- a/src/lib/contexts/my-user-context.svelte.ts
+++ b/src/lib/contexts/my-user-context.svelte.ts
@@ -435,7 +435,7 @@ export class MyUserContext {
       );
 
       // TODO: This isn't appropriately returning false where the code was incorrect
-      console.log('verify response: ', response.object)
+      console.log('verify response: ', response.object);
 
       if (response.error || !response.object) {
         console.error(

--- a/src/routes/reset-password/reset-password-form.svelte
+++ b/src/routes/reset-password/reset-password-form.svelte
@@ -1,13 +1,10 @@
 <script lang="ts">
   import AuthCard from '@/components/auth-card.svelte';
   import {
-  determineIdentifierType,
-    emailSchema,
     getOtpMessage,
     schemaFirstStep,
     schemaLastStep,
     schemaStepTwo,
-    usernameSchema,
     type ResetPasswordFormSchema,
   } from './schema';
   import SuperDebug, { type SuperValidated, type Infer, superForm } from 'sveltekit-superforms';
@@ -15,42 +12,47 @@
   import { AppUiMessage, MsaTokenStatus } from '@/types/enums.js';
   import { myUserContext } from '@/contexts/my-user-context.svelte.js';
   import translate from '@/helpers/language/translate.js';
-  import {
-  MultiStepActionEventType,
-    SidMultiStepActionProgress,
-    UserIdentType,
-  } from '@baragaun/bg-node-client';
+  import { UserIdentType } from '@baragaun/bg-node-client';
   import { onDestroy } from 'svelte';
   import passwordHelpers from '@/helpers/password-helpers.js';
-  import { goto } from '$app/navigation';
+  import { beforeNavigate, goto } from '$app/navigation';
 
   import EmailFormInput from '@/components/forms/form-ident-input.svelte';
   import OtpFormInput from '@/components/forms/form-otp-input.svelte';
   import UpdatePasswordFormInput from '@/components/forms/form-update-password-input.svelte';
   import FormButton from '@/components/forms/form-button.svelte';
   import { MsaListenerHandler } from '@/contexts/msa-listener-handler.svelte';
+  import { determineIdentifierType } from '../signup/form/schema';
 
   let { data }: { data: { form: SuperValidated<Infer<ResetPasswordFormSchema>> } } = $props();
 
   const steps = [zod(schemaFirstStep), zod(schemaStepTwo), zod(schemaLastStep)];
   let step = $state(1);
   const getCurrentValidator = () => steps[step - 1];
-  
-  // let otpHandler: MsaListenerHandler | undefined = $state(undefined);
+
+  let otpHandler: MsaListenerHandler | undefined = $state(undefined);
   let msaActionId = $state<string | undefined>(undefined);
   let msaActionStatus = $state(MsaTokenStatus.unset);
   let resendTimer = $state(30);
   let canResend = $state(false);
-      
+
   let loading = $state(false);
+  let message = $state('');
   let errorMessage = $state('');
   let hasStepError = $state(true); // Treat an initial empty input as an error
-  
+
   let identifier = $state('');
   let identType = $state(UserIdentType.email);
 
   let debounceTimer: number | null = null;
   const DEBOUNCE_DELAY = 350; // ms
+
+  $effect(() => {
+    if (otpHandler) {
+      errorMessage = otpHandler.errorMessage;
+      message = otpHandler.message;
+    }
+  });
 
   const form = superForm(data.form, {
     dataType: 'json',
@@ -89,10 +91,10 @@
       if (step === 1) {
         await startPasswordReset();
       } else if (step === 2) {
-        console.log('>>>>> calling verify token: ', errorMessage)
+        console.log('>>>>> calling verify token: ', errorMessage);
         await verifyResetPasswordToken();
       } else if (step === 3) {
-        console.log('>>>>> callling update: ', errorMessage)
+        console.log('>>>>> callling update: ', errorMessage);
         await updatePassword();
       }
 
@@ -146,111 +148,9 @@
       }
 
       msaActionId = response.object.actionProgress.actionId;
-      response.object.run.addListener({
-        id: 'ResetPassword',
-        onEvent: async (
-          eventType: MultiStepActionEventType,
-          action: SidMultiStepActionProgress,
-        ): Promise<void> => {
-          if (eventType === MultiStepActionEventType.notificationFailed) {
-            // The notification failed to go out.
-            if (import.meta.env.VITE_APP_ENVIRONMENT === 'development') {
-              // We can ignore the failure to send the email in development.
-              console.log('DEVELOPMENT')
-              // If an error throws, the ident cannot be found
-              errorMessage = translate(AppUiMessage.msaTokenFailedToSend, AppUiMessage.systemError)
-              errors.update((errors) => ({
-                ...errors,
-                token: [errorMessage],
-              }));
-              return;
-            }
-            console.error(
-              `ResetPasswordForm.multiStepActionListener: Notification failed.`,
-              action.notificationResult,
-            );
-            msaActionStatus = MsaTokenStatus.sendingFailed;
-            errorMessage = translate(AppUiMessage.msaTokenFailedToSend, AppUiMessage.systemError);
-            errors.update((errors) => ({
-              ...errors,
-              token: [errorMessage],
-            }));
-            return;
-          }
-
-          if (eventType === MultiStepActionEventType.notificationSent) {
-            // The notification has been sent out.
-            console.log(
-              `ResetPasswordForm.multiStepActionListener: Notification sent out.`,
-              action.notificationResult,
-            );
-
-            msaActionStatus = MsaTokenStatus.notificationSent;
-            errorMessage = translate(AppUiMessage.msaTokenSent);
-            // todo this shows up as error
-            errors.update((errors) => ({
-                ...errors,
-                token: [errorMessage],
-              }));
-            return;
-          }
-
-          if (eventType === MultiStepActionEventType.tokenFailed) {
-            console.error(
-              `ResetPasswordForm.multiStepActionListener: incorrect token.`,
-              action.notificationResult,
-            );
-            errorMessage = 'We could not verify the token you entered. Please try again.';
-            errors.update((errors) => ({
-                ...errors,
-                token: [errorMessage],
-              }));
-
-              // We are advancing to step 3 before this comes back as failed, aka "accepting an invalid token"
-
-            return;
-          }
-
-          if (eventType === MultiStepActionEventType.timedOut) {
-            console.error(
-              `ResetPasswordForm.multiStepActionListener: timeout.`,
-              action.notificationResult,
-            );
-            msaActionStatus = MsaTokenStatus.sendingFailed;
-            errorMessage = translate(AppUiMessage.msaTokenFailedToSend, AppUiMessage.systemError);
-            errors.update((errors) => ({
-                ...errors,
-                token: [errorMessage],
-              }));
-            return;
-          }
-
-          if (eventType === MultiStepActionEventType.failed) {
-            console.error(`ResetPasswordForm.multiStepActionListener: error.`, action.notificationResult);
-            msaActionStatus = MsaTokenStatus.verificationFailed;
-            errorMessage = translate(AppUiMessage.msaTokenFailedToSend, AppUiMessage.systemError);
-            errors.update((errors) => ({
-                ...errors,
-                token: [errorMessage],
-              }));
-            return;
-          }
-
-          if (eventType === MultiStepActionEventType.success) {
-            // The token was accepted. The user is now signed in.
-            console.log(`ResetPasswordForm.multiStepActionListener: success.`, action.notificationResult);
-            msaActionStatus = MsaTokenStatus.success;
-            errorMessage = translate(AppUiMessage.msaTokenSuccess);
-            // TODO: this shows up as an error
-            errors.update((errors) => ({
-                ...errors,
-                token: [errorMessage],
-            }));
-          }
-        },
+      otpHandler = new MsaListenerHandler('ResetPassword', response, () => {
+        step = 3;
       });
-
-      // We advance instead of waiting for the poll to come back with a `sent` status
       step = 2;
       startResendTimer();
       return;
@@ -308,20 +208,20 @@
         $formData.token,
       );
 
-      console.log('>>>>> got a token verification response: ', response)
+      console.log('>>>>> got a token verification response: ', response);
 
       if (response !== true) {
         console.error('ResetPasswordForm.verifyResetPasswordToken: invalid response:', {
           result: response,
         });
         errorMessage = translate(AppUiMessage.systemError);
-        console.log('>>>>> but we have an error: ', errorMessage)
+        console.log('>>>>> but we have an error: ', errorMessage);
         msaActionStatus = MsaTokenStatus.unset;
         return;
       }
 
       msaActionStatus = MsaTokenStatus.sending;
-      console.log('>>>>> heading to step 3')
+      console.log('>>>>> heading to step 3');
       step = 3;
     } catch (error) {
       console.error('ResetPasswordForm.verifyResetPasswordToken: error:', { error });
@@ -341,12 +241,12 @@
     errorMessage = '';
 
     if (!$formData.newPassword) return;
-    console.log('>>>>> we bailed for no pass: ', errorMessage)
+    console.log('>>>>> we bailed for no pass: ', errorMessage);
 
     try {
       if (!validatePassword($formData.newPassword).isValid) {
         errorMessage = getPasswordError($formData.newPassword);
-        console.log('>>>>> failed password validation check: ', errorMessage)
+        console.log('>>>>> failed password validation check: ', errorMessage);
         return;
       }
       const result = await myUserContext.verifyMultiStepActionToken(
@@ -355,15 +255,15 @@
         $formData.newPassword,
       );
 
-      console.log('>>>>> got update result: ', result)
+      console.log('>>>>> got update result: ', result);
 
       if (result !== true) {
         errorMessage = typeof result === 'string' ? result : 'Failed to verify code';
-        console.log('>>>>> we got an error: ', errorMessage)
+        console.log('>>>>> we got an error: ', errorMessage);
         return;
       }
 
-      console.log('>>>>> we should be fine, so we sign in: ', errorMessage)
+      console.log('>>>>> we should be fine, so we sign in: ', errorMessage);
 
       const response = await myUserContext.signMeInWithPassword(
         $formData.ident,
@@ -371,11 +271,11 @@
         $formData.newPassword,
       );
 
-      console.log('>>>>> sign in response: ', response)
+      console.log('>>>>> sign in response: ', response);
 
       if (response !== true) {
         errorMessage = response;
-        console.log('>>>>> we got an error at the last second: ', errorMessage)
+        console.log('>>>>> we got an error at the last second: ', errorMessage);
         return;
       }
 
@@ -391,6 +291,17 @@
 
   onDestroy(() => {
     clearInterval(timerInterval);
+    if (otpHandler) {
+      otpHandler.removeListener();
+      otpHandler = undefined;
+    }
+  });
+
+  beforeNavigate(() => {
+    if (otpHandler) {
+      otpHandler.removeListener();
+      otpHandler = undefined;
+    }
   });
 
   $effect(() => {
@@ -418,10 +329,26 @@
         return 'Now, update your password.';
     }
   };
+
+  const onBack = () => {
+    if (otpHandler) {
+      otpHandler.removeListener();
+      otpHandler = undefined;
+    }
+
+    if (step > 1) {
+      step = step - 1;
+    }
+  };
 </script>
 
 <form method="POST" id="reset-password-form" use:enhance>
-  <AuthCard title="Reset your password" description={getCurrentStepDescription()}>
+  <AuthCard
+    title="Reset your password"
+    description={getCurrentStepDescription()}
+    showBackButton={step > 1}
+    {onBack}
+  >
     <div class="space-y-4">
       {#if step == 1}
         <EmailFormInput

--- a/src/routes/signin/sign-in-form.svelte
+++ b/src/routes/signin/sign-in-form.svelte
@@ -22,6 +22,7 @@
   import { Button } from '$lib/components/ui/button';
   import { goto } from '$app/navigation';
   import { onDestroy } from 'svelte';
+  import { beforeNavigate } from '$app/navigation';
 
   let { data }: { data: { form: SuperValidated<SignInFormSchema> } } = $props();
 
@@ -44,10 +45,17 @@
   let message = $state('');
   let errorMessage = $state('');
   let hasStepError = $state(true);
-  
+
   let identifier = $state('');
   let identType = $state(UserIdentType.email);
-  const emailCooldowns = $state(new Map<string, number>());  // Track emails that have active cooldowns
+  const emailCooldowns = $state(new Map<string, number>()); // Track emails that have active cooldowns
+
+  $effect(() => {
+    if (otpHandler) {
+      errorMessage = otpHandler.errorMessage;
+      message = otpHandler.message;
+    }
+  });
 
   const form = superForm(data.form, {
     dataType: 'json',
@@ -124,13 +132,13 @@
     // 4. Go to the others step
 
     if (otpHandler) {
-      console.log('togleeauth clearing our otp handler')
+      console.log('togleeauth clearing our otp handler');
       otpHandler.removeListener();
       otpHandler = undefined;
     }
 
     const result = await validateForm({ update: true, focusOnError: false });
-    
+
     if (step === 1) {
       // Ensure that there is valid ident input before we request a token
       if (result.valid) {
@@ -138,25 +146,24 @@
         $formData.token = '';
         form.errors.subscribe((errors) => {
           if (errors.password && errors.password.length > 0) {
-            console.log('blast the password away: ', errors.password)
+            console.log('blast the password away: ', errors.password);
             $formData.password = undefined;
           }
-        })
+        });
         await sendTokenForSignIn();
-        step = 2
+        step = 2;
       }
-
     } else {
       $formData.authType = 'password';
       $formData.password = '';
       // $formData.token = undefined;
       form.errors.subscribe((errors) => {
         if (errors.token && errors.token.length > 0) {
-          console.log('blast the token away: ', errors.token)
+          console.log('blast the token away: ', errors.token);
           $formData.token = undefined;
         }
-      })
-      step = 1
+      });
+      step = 1;
     }
 
     errorMessage = '';
@@ -250,7 +257,9 @@
       }
       startResendTimer();
       mfaActionId = response.object.actionProgress.actionId;
-      otpHandler = new MsaListenerHandler('SignInForm', response, () => {goto('/')});
+      otpHandler = new MsaListenerHandler('SignInForm', response, () => {
+        goto('/');
+      });
 
       return;
     } catch (error) {
@@ -345,6 +354,13 @@
     }
   });
 
+  beforeNavigate(() => {
+    if (otpHandler) {
+      otpHandler.removeListener();
+      otpHandler = undefined;
+    }
+  });
+
   $effect(() => {
     if (debounceTimer) {
       clearTimeout(debounceTimer);
@@ -371,10 +387,26 @@
         return getOtpMessage($formData);
     }
   };
+
+  const onBack = () => {
+    if (otpHandler) {
+      otpHandler.removeListener();
+      otpHandler = undefined;
+    }
+
+    if (step > 1) {
+      step = step - 1;
+    }
+  };
 </script>
 
 <form method="POST" id="sign-in-form" use:enhance>
-  <AuthCard title="Sign in" description={getCurrentStepDescription()}>
+  <AuthCard
+    title="Sign in"
+    description={getCurrentStepDescription()}
+    showBackButton={step > 1}
+    {onBack}
+  >
     <div class="space-y-4">
       {#if step === 1}
         <IdentInputComponent
@@ -396,11 +428,7 @@
           loadingText="Signing in..."
         />
         <div class="flex justify-between text-sm">
-          <Button 
-            variant="link" 
-            disabled={!$formData.ident}
-            onclick={() => toggleAuthType()}
-          >
+          <Button variant="link" disabled={!$formData.ident} onclick={() => toggleAuthType()}>
             Sign in with token
           </Button>
           <Button variant="link" onclick={async () => await goto('reset-password')}>
@@ -425,10 +453,7 @@
           loadingText="Signing in..."
         />
         <div class="flex justify-between text-sm">
-          <Button
-            variant="link"
-            onclick={async () => await toggleAuthType()}
-          >
+          <Button variant="link" onclick={async () => await toggleAuthType()}>
             Sign in with password
           </Button>
           <Button variant="link" onclick={async () => await goto('reset-password')}>

--- a/src/routes/signup/form/sign-up-form2.svelte
+++ b/src/routes/signup/form/sign-up-form2.svelte
@@ -1,11 +1,6 @@
 <script lang="ts">
-  import { Button } from '$lib/components/ui/button';
-  import { goto } from '$app/navigation';
-  import {
-    MultiStepActionEventType,
-    SidMultiStepActionProgress,
-    UserIdentType,
-  } from '@baragaun/bg-node-client';
+  import { beforeNavigate, goto } from '$app/navigation';
+  import { UserIdentType } from '@baragaun/bg-node-client';
   import translate from '@/helpers/language/translate';
   import { AppUiMessage, MsaTokenStatus } from '@/types/enums';
   import { myUserContext } from '@/contexts/my-user-context.svelte';
@@ -18,7 +13,6 @@
   import { onDestroy } from 'svelte';
   import AuthCard from '@/components/auth-card.svelte';
   import {
-    determineIdentifierType,
     emailSchema,
     schemaFirstStep,
     schemaLastStep,
@@ -27,6 +21,7 @@
     type SignInFormSchema,
   } from './schema';
   import FormUpdatePasswordInput from '@/components/forms/form-update-password-input.svelte';
+  import { MsaListenerHandler } from '@/contexts/msa-listener-handler.svelte';
 
   let { data }: { data: { form: SuperValidated<SignInFormSchema> } } = $props();
 
@@ -46,11 +41,19 @@
   let mfaActionId = $state<string | undefined>(undefined);
   let message = $state('');
   let timerInterval: ReturnType<typeof setInterval>;
+  let otpHandler: MsaListenerHandler | undefined = $state(undefined);
 
   const getCurrentValidator = () => steps[step - 1];
 
   let debounceTimer: number | null = null;
   const DEBOUNCE_DELAY = 350; // ms
+
+  $effect(() => {
+    if (otpHandler) {
+      errorMessage = otpHandler.errorMessage;
+      message = otpHandler.message;
+    }
+  });
 
   const form = superForm(data.form, {
     dataType: 'json',
@@ -67,7 +70,7 @@
 
       debounceTimer = window.setTimeout(async () => {
         try {
-          await validateForm({ update: true });
+          await validateForm({ update: true, focusOnError: false });
 
           if (step === 1) {
             hasStepError = !(await checkIdentAvailability());
@@ -98,7 +101,7 @@
       }
 
       if (step === 1) {
-        // await registerNewEmail();
+        await registerNewEmail();
         step = 2;
       } else if (step === 2) {
         await verifyEmailToken($formData.token);
@@ -218,81 +221,11 @@
       startResendTimer();
 
       mfaActionId = response.object.actionProgress.actionId;
-
-      response.object.run.addListener({
-        id: 'SignUpForm',
-        onEvent: async (
-          eventType: MultiStepActionEventType,
-          action: SidMultiStepActionProgress,
-        ): Promise<void> => {
-          if (eventType === MultiStepActionEventType.notificationFailed) {
-            // The notification failed to go out.
-            console.error(
-              'SignUpForm.multiStepActionListener: Notification failed.',
-              action.notificationResult,
-            );
-
-            if (import.meta.env.VITE_APP_ENVIRONMENT === 'development') {
-              // We can ignore the failure to send the email in development.
-              errorMessage = '';
-              return;
-            } else {
-              errorMessage =
-                'We could not send the verification token to your email. Please try again.';
-            }
-
-            tokenStatus = MsaTokenStatus.sendingFailed;
-            errorMessage = translate(AppUiMessage.msaTokenFailedToSend, AppUiMessage.systemError);
-            return;
-          }
-
-          if (eventType === MultiStepActionEventType.notificationSent) {
-            // The notification has been sent out.
-            console.log(
-              'SignUpForm.multiStepActionListener: Notification sent out.',
-              action.notificationResult,
-            );
-            // Switching to the token input for
-            tokenStatus = MsaTokenStatus.notificationSent;
-            message = translate(AppUiMessage.msaTokenSent);
-            return;
-          }
-
-          if (eventType === MultiStepActionEventType.tokenFailed) {
-            console.error(
-              'SignUpForm.multiStepActionListener: incorrect token.',
-              action.notificationResult,
-            );
-            errorMessage = 'We could not verify the token you entered. Please try again.';
-            return;
-          }
-
-          if (eventType === MultiStepActionEventType.timedOut) {
-            console.error(
-              'SignUpForm.multiStepActionListener: timeout.',
-              action.notificationResult,
-            );
-            tokenStatus = MsaTokenStatus.sendingFailed;
-            errorMessage = translate(AppUiMessage.msaTokenFailedToSend, AppUiMessage.systemError);
-            return;
-          }
-
-          if (eventType === MultiStepActionEventType.failed) {
-            console.error('SignUpForm.multiStepActionListener: error.', action.notificationResult);
-            tokenStatus = MsaTokenStatus.verificationFailed;
-            errorMessage = translate(AppUiMessage.msaTokenFailedToSend, AppUiMessage.systemError);
-            return;
-          }
-
-          if (eventType === MultiStepActionEventType.success) {
-            // The token was accepted. The user is now signed in.
-            console.log('SignUpForm.multiStepActionListener: success.', action.notificationResult);
-            tokenStatus = MsaTokenStatus.success;
-            message = translate(AppUiMessage.msaTokenSuccess);
-            goto('/');
-          }
-        },
+      otpHandler = new MsaListenerHandler('SignUpForm', response, () => {
+        step = 3;
       });
+
+      return;
     } catch (error) {
       console.error('SignUpForm.registerNewEmail:', { error });
       tokenStatus = MsaTokenStatus.verificationFailed;
@@ -394,6 +327,17 @@
 
   onDestroy(() => {
     clearInterval(timerInterval);
+    if (otpHandler) {
+      otpHandler.removeListener();
+      otpHandler = undefined;
+    }
+  });
+
+  beforeNavigate(() => {
+    if (otpHandler) {
+      otpHandler.removeListener();
+      otpHandler = undefined;
+    }
   });
 
   $effect(() => {
@@ -420,10 +364,37 @@
         return 'Choose a username and a password.';
     }
   };
+
+  const getCurrentButtonLabel = () => {
+    switch (step) {
+      case 1:
+        return 'Continue';
+      case 2:
+        return 'Verify my email';
+      case 3:
+        return 'Create Account';
+    }
+  };
+
+  const onBack = () => {
+    if (otpHandler) {
+      otpHandler.removeListener();
+      otpHandler = undefined;
+    }
+
+    if (step > 1) {
+      step = step - 1;
+    }
+  };
 </script>
 
 <form method="POST" id="sign-up-form" use:enhance>
-  <AuthCard title="Sign up" description={getCurrentStepDescription()}>
+  <AuthCard
+    title="Sign up"
+    description={getCurrentStepDescription()}
+    showBackButton={step > 1}
+    {onBack}
+  >
     <div class="space-y-4">
       {#if step === 1}
         <!-- TODO: this should be called identinput -->
@@ -461,8 +432,8 @@
       <FormButtonComponent
         disabled={$delayed || isValidating || hasStepError}
         loading={$delayed}
-        buttonText="Sign in"
-        loadingText="Signing in..."
+        buttonText={getCurrentButtonLabel()}
+        loadingText="Processing..."
       />
       <div class="mt-4 text-center text-sm">
         Don't have an account?


### PR DESCRIPTION
I worked on the following this in this PR.

- What’s the recommended way to remove listeners when navigating between pages or going back?
- Reset Password: Even with an invalid token, I'm still able to set a new password. Ideally, the user should be blocked from proceeding.
- No listener-related errors are appearing on the Sign In page.
- The "Step Back" button is missing in UI.


My suggestion for **production** to add one more function `onSentNotification` in `msa-listener-handle.svelte` just like `onSuccess?`.
We will call onSentNotification like the given below.
```
  if (eventType === MultiStepActionEventType.notificationSent) {
        console.log(
          `${this.listenerId}.multiStepActionListener: notificationSent.`,
          action.notificationResult,
        );
        this.tokenStatus = MsaTokenStatus.notificationSent;
        this.message = translate(AppUiMessage.msaTokenSent);

        // Proceed with any callback
        if (this.onSentNotification) this.onSentNotification();
 }
```

Why need onSentNotification function?
It will help us to show otp input field when server sent the message, if server fails user will get respective error for it.