### PR TITLE
fix findAvailableUserHandle api call response handling and some refactoring

### DIFF
--- a/src/lib/components/forms/form-ident-input.svelte
+++ b/src/lib/components/forms/form-ident-input.svelte
@@ -18,7 +18,7 @@
     disabled = false,
     identType = UserIdentType.email,
     isLoading = false,
-    generateUsername = undefined,
+    suggestUsername = undefined,
   } = $props<{
     form: SuperForm<T>;
     fieldName?: FormPathLeaves<T>;
@@ -27,7 +27,7 @@
     disabled?: boolean;
     identType?: UserIdentType;
     isLoading?: boolean;
-    generateUsername?: () => Promise<void>;
+    suggestUsername?: () => Promise<void>;
   }>();
 
   const { form: formData, errors } = form;
@@ -43,7 +43,7 @@
             <Form.Label>{label}</Form.Label>
           </div>
 
-          {#if isUserHandle && generateUsername && $errors[fieldName]}
+          {#if isUserHandle && suggestUsername && $errors[fieldName]}
             <button
               type="button"
               class={cn(
@@ -52,7 +52,7 @@
                 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
                 'disabled:pointer-events-none disabled:opacity-50',
               )}
-              onclick={() => generateUsername()}
+              onclick={() => suggestUsername()}
             >
               <RefreshCw class={cn('mr-1 h-3 w-3', isLoading && 'animate-spin')} />
               {isLoading ? 'Generating...' : 'Suggest new'}

--- a/src/lib/components/forms/form-password-input.svelte
+++ b/src/lib/components/forms/form-password-input.svelte
@@ -20,8 +20,7 @@
     label?: string;
   }>();
 
-  const formData = form.form;
-  const errors = form.errors;
+  const { form: formData, errors } = form;
 
   let showPassword = $state(false);
 </script>

--- a/src/routes/reset-password/reset-password-form.svelte
+++ b/src/routes/reset-password/reset-password-form.svelte
@@ -75,7 +75,7 @@
       }, DEBOUNCE_DELAY);
     },
     async onSubmit({ cancel }) {
-      cancel();  // Avoid the actual server-side validation form action
+      cancel(); // Avoid the actual server-side validation form action
 
       const result = await validateForm({ update: true, focusOnError: true });
       if (!result.valid) return;
@@ -117,7 +117,7 @@
       };
       return newErrors;
     });
-  }
+  };
 
   const startPasswordReset = async () => {
     isLoading = true;
@@ -299,7 +299,7 @@
     }
   };
 
-    const getCurrentStepDescription = () => {
+  const getCurrentStepDescription = () => {
     switch (step) {
       case 1:
         return 'Provide your email address to receive a verification code and update your password.';
@@ -337,7 +337,7 @@
     } finally {
       isLoading = false;
     }
-  }
+  };
 
   $effect(() => {
     if (debounceTimer) {

--- a/src/routes/signin/sign-in-form.svelte
+++ b/src/routes/signin/sign-in-form.svelte
@@ -126,7 +126,7 @@
       };
       return newErrors;
     });
-  }
+  };
 
   const toggleAuthType = async () => {
     // 1. Remove an existing listener that hasn't failed yet

--- a/src/routes/signup/sign-up-form.svelte
+++ b/src/routes/signup/sign-up-form.svelte
@@ -345,7 +345,9 @@
       isLoading = true;
       const result = await myUserContext.findAvailableUserHandle($formData.email);
 
-      if (typeof result === 'string') {
+      if (result && typeof result === 'object' && 'object' in result) {
+        $formData.username = result.object ?? '';
+      } else if (typeof result === 'string') {
         $formData.username = result;
       }
     } catch (error) {
@@ -439,7 +441,7 @@
           placeholder="e.g. 'giraffe08'"
           label="Username"
           {identType}
-          generateUsername={getSuggestedUsername}
+          suggestUsername={getSuggestedUsername}
           {isLoading}
         />
         <PasswordFormInput

--- a/src/routes/signup/sign-up-form.svelte
+++ b/src/routes/signup/sign-up-form.svelte
@@ -336,11 +336,6 @@
   const getSuggestedUsername = async () => {
     if (!$formData.email) return;
 
-    if (myUserContext.myUserHandle) {
-      $formData.username = myUserContext.myUserHandle;
-      return;
-    }
-
     try {
       isLoading = true;
       const result = await myUserContext.findAvailableUserHandle($formData.email);

--- a/src/stories/forms/FormOtpInput.stories.svelte
+++ b/src/stories/forms/FormOtpInput.stories.svelte
@@ -10,7 +10,7 @@
       subscribe,
       set,
       update,
-      clear: () => set({})
+      clear: () => set({}),
     };
   }
 
@@ -22,7 +22,7 @@
     errors: {},
     data: { token: '' },
     constraints: {},
-    message: ''
+    message: '',
   };
 
   const { Story } = defineMeta({
@@ -32,7 +32,7 @@
       layout: 'centered',
     },
     argTypes: {
-      form  : {
+      form: {
         control: { type: 'object' },
         description: 'The form object',
       },
@@ -54,10 +54,8 @@
           run({ token: '123456' }); // token field value
           return function unsubscribe() {};
         },
-        set: function (value, options) {
-        },
-        update: function (updater, options) {
-        }
+        set: function (value, options) {},
+        update: function (updater, options) {},
       },
       errors: createMockErrorsStore(),
       constraints: writable({}),
@@ -72,16 +70,14 @@
       options: mockOptions,
       enhance: function (_el, _events) {
         return {
-          destroy: () => {}
+          destroy: () => {},
         };
       },
       isTainted: function (path) {
         return false; // Return a boolean value instead of throwing an error
       },
-      reset: function (options) {
-      },
-      submit: function (submitter) {
-      },
+      reset: function (options) {},
+      submit: function (submitter) {},
       capture: function () {
         throw new Error('Function not implemented.');
       },
@@ -93,7 +89,7 @@
       },
       validateForm: function (opts) {
         throw new Error('Function not implemented.');
-      }
+      },
     },
     fieldName: 'token',
   }}


### PR DESCRIPTION
Hello @jonahtwalker ,  

In this PR, I’ve correctly handled the response of the `findAvailableUserHandle` API call.  

In our previous [[PR](https://github.com/baragaun/first-spark-app/pull/75)](https://github.com/baragaun/first-spark-app/pull/75), you had added [[this comment](https://github.com/baragaun/first-spark-app/pull/75#discussion_r2047909259)](https://github.com/baragaun/first-spark-app/pull/75#discussion_r2047909259) and I had responded there as well, but the PR had already been merged by then.  

So, in this PR,

- I’ve addressed  the issue: the response type of `findAvailableUserHandle` is actually an object, not a string. I’ve updated the logic accordingly to reflect that.  
- refactored and formated some files

For reference, I’ve included a screen recording showing the behavior with and without this fix:


https://github.com/user-attachments/assets/e0b601a7-4d35-4912-9755-01bc5626eec8


<img width="580" alt="Screenshot 2025-04-17 at 11 25 20 AM" src="https://github.com/user-attachments/assets/11ec2974-620b-4992-aa45-aa4ae79e5a85" />


Thanks!


