### PR TITLE
Rr/unauthenticated UI update

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "welcome": "Willkommen bei First Spark",
   "welcome_subtitle": "Verbinden, inspirieren, wachsen!",
+  "join_first_spark": "Mach mit bei First Spark",
   "get_started": "Jetzt starten",
   "sidebar": {
     "logo": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "welcome": "Welcome to First Spark",
   "welcome_subtitle": "Connect, inspire, thrive!",
+  "join_first_spark": "Join First Spark",
   "get_started": "Get Started",
   "sidebar": {
     "logo": {

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -2,6 +2,7 @@
   "$schema": "https://inlang.com/schema/inlang-message-format",
   "welcome": "फर्स्ट स्पार्क में आपका स्वागत है",
   "welcome_subtitle": "जुड़ें, प्रेरित करें, विकसित हों!",
+  "join_first_spark": "फर्स्ट स्पार्क से जुड़ें",
   "get_started": "शुरू करें",
   "sidebar": {
     "logo": {

--- a/src/lib/components/global/app-sidebar.svelte
+++ b/src/lib/components/global/app-sidebar.svelte
@@ -71,7 +71,7 @@
   const sidebar = Sidebar.useSidebar();
 
   const handleItemClick = () => {
-    if (sidebar.isMobile) {
+    if (sidebar && sidebar.isMobile) {
       sidebar.setOpenMobile(false);
     }
   };

--- a/src/lib/components/global/app-sidebar.svelte
+++ b/src/lib/components/global/app-sidebar.svelte
@@ -116,10 +116,16 @@
           <h2 class="mb-3 text-sm font-bold">{m['join_first_spark']()}</h2>
           <h3 class="mb-3 text-sm font-medium">{m['welcome_subtitle']()}</h3>
           <div class="flex flex-col gap-2">
-            <Button href="/signup" size="sm" class="w-full">
+            <Button href="/signup" size="sm" class="w-full" onclick={handleItemClick}>
               {m['get_started']()}
             </Button>
-            <Button href="/signin" variant="outline" size="sm" class="w-full">
+            <Button
+              href="/signin"
+              variant="outline"
+              size="sm"
+              class="w-full"
+              onclick={handleItemClick}
+            >
               {m['nav.auth.sign_in']()}
             </Button>
           </div>
@@ -128,7 +134,7 @@
     {/if}
 
     <Sidebar.Group
-      class="mb-2 {!isSignedIn ? '' : 'mt-auto'} px-3 group-data-[collapsible=icon]:mt-auto"
+      class={`mb-2 ${!isSignedIn ? '' : 'mt-auto'} px-3 group-data-[collapsible=icon]:mt-auto`}
     >
       <Sidebar.Menu>
         <Sidebar.MenuItem>

--- a/src/lib/components/global/app-sidebar.svelte
+++ b/src/lib/components/global/app-sidebar.svelte
@@ -33,16 +33,19 @@
       title: m['sidebar.menu.inbox'](),
       url: '#',
       icon: Inbox,
+      requiresAuth: true,
     },
     {
       title: m['sidebar.menu.conversations'](),
       url: '#',
       icon: MessageSquare,
+      requiresAuth: true,
     },
     {
       title: m['sidebar.menu.contacts'](),
       url: '#',
       icon: BookUser,
+      requiresAuth: true,
     },
     {
       title: m['sidebar.menu.settings'](),
@@ -106,7 +109,27 @@
         {/each}
       </Sidebar.Menu>
     </Sidebar.Group>
-    <Sidebar.Group class="mb-2 mt-auto">
+
+    {#if !isSignedIn}
+      <Sidebar.Group class="mb-2 mt-auto px-3 group-data-[collapsible=icon]:hidden">
+        <div class="rounded-lg border border-border bg-card p-4 shadow-sm">
+          <h2 class="mb-3 text-sm font-bold">{m['join_first_spark']()}</h2>
+          <h3 class="mb-3 text-sm font-medium">{m['welcome_subtitle']()}</h3>
+          <div class="flex flex-col gap-2">
+            <Button href="/signup" size="sm" class="w-full">
+              {m['get_started']()}
+            </Button>
+            <Button href="/signin" variant="outline" size="sm" class="w-full">
+              {m['nav.auth.sign_in']()}
+            </Button>
+          </div>
+        </div>
+      </Sidebar.Group>
+    {/if}
+
+    <Sidebar.Group
+      class="mb-2 {!isSignedIn ? '' : 'mt-auto'} px-3 group-data-[collapsible=icon]:mt-auto"
+    >
       <Sidebar.Menu>
         <Sidebar.MenuItem>
           <Sidebar.MenuButton>

--- a/src/lib/components/global/nav-bar/nav-bar.svelte
+++ b/src/lib/components/global/nav-bar/nav-bar.svelte
@@ -30,8 +30,8 @@
 
     <!-- Right side items -->
     <div class="flex flex-none items-center gap-2">
-      <ThemeButton class="hidden md:flex" />
-      <LanguageButton class="hidden md:flex" />
+      <ThemeButton class="flex" />
+      <LanguageButton class="flex" />
       {#if !isSignedIn}
         <div class="flex flex-none items-center gap-2">
           <Button

--- a/src/routes/settings/account/account-settings.svelte
+++ b/src/routes/settings/account/account-settings.svelte
@@ -73,9 +73,8 @@
   </div>
 
   <Separator />
-
   <h4 class="font-lexend text-lg font-bold">Danger Zone</h4>
-  <div class="space-y-4">
+  <div class="flex cursor-pointer items-center justify-between rounded-lg hover:bg-muted/50">
     <SettingsDialog
       label="Delete my account"
       sublabel="Permanently delete your account and any associated data"

--- a/src/routes/settings/account/components/settings-dialog.svelte
+++ b/src/routes/settings/account/components/settings-dialog.svelte
@@ -25,7 +25,7 @@
     children?: Snippet;
   }>();
 
-  const hoverColor = destructive ? 'bg-destructive/10' : 'bg-secondary';
+  const hoverColor = destructive ? 'bg-destructive/10' : 'bg-muted/50';
   const textColor = destructive ? 'text-destructive' : '';
 
   $effect(() => {

--- a/tests/e2e/landing.spec.ts
+++ b/tests/e2e/landing.spec.ts
@@ -7,12 +7,14 @@ test('Landing page has welcome text, Get Started Button', async ({ page }) => {
   const welcomeText = page.getByText('Welcome to First Spark');
   await expect(welcomeText).toBeVisible();
 
-  // Verify the subtext is also present
-  const subtextElement = page.getByText('Connect, inspire, thrive!');
+  // Verify the subtext is also present - use a more specific selector
+  const subtextElement = page
+    .getByRole('paragraph')
+    .filter({ hasText: 'Connect, inspire, thrive!' });
   await expect(subtextElement).toBeVisible();
 
-  // Check for the Get Started button
-  const getStartedButton = page.getByText('Get Started');
+  // Check for the Get Started button in the main content area
+  const getStartedButton = page.getByRole('main').getByRole('link', { name: 'Get Started' });
   await expect(getStartedButton).toBeVisible();
 });
 


### PR DESCRIPTION
<!-- This template is to serve as a comprehensive outline for documenting updates to the code. Some of these sections may not be relevant to your PR. In that case, document it inline with `N/A`  -->

## What does this PR do?
<!-- Provide a clear and concise description of what this PR accomplishes -->

- This PR refactors the app’s authentication gating by restricting access to authenticated-only content and ensuring visibility and routing behavior reflect authentication state. 
- It also updates the sidebar UI for unauthenticated users with a dedicated section that includes "Get Started" and "Sign In" buttons.
- Also added hovering effect for Account-setting menu options
- No option to change language or theme on small devices

### Related Issues & PRs
<!-- List the related issues, using either: `Closes #123` or `Fixes #123` , which will automatically move the specified issue to "In Review" when the PR is created -->
Update what is visible when not authenticated #84
No option to change language or theme on small devices [#98](https://github.com/baragaun/first-spark-app/issues/98)

#### Key Decisions
<!-- Explain the technical decisions and alternative approaches considered for your new implementations and refactored solutions -->
- Limited visibility of app content to only the Welcome, Sign In, Sign Up, and Reset Password pages when unauthenticated.
- Refactored SideBar to show only the "Home" route and auth buttons when the user is not signed in.
- Added a new section at the bottom of the sidebar for unauthenticated users with:
A "Get Started" button.
A "Sign In" button styled with the outline variant.

## Breaking Changes
<!-- Do others need to do something to successfully incorporate your changes into their work? -->
- [ ] This PR includes breaking changes
  <!-- What do they need to do? -->
N/A

### Limitations & Concerns
<!-- Describe any limitations, potential edge cases, or situations where your solution might break -->
- **Known limitations**: None at this stage.
---

### UI Changes
<!-- If this PR modifies the UI, provide screenshots and descriptions -->
- [ ] This PR includes UI changes
<!-- Include screenshots in the table below, include before & after applicable -->

### Screen Recording
| Description | Screenshot |

https://github.com/user-attachments/assets/266551fa-54d2-4566-98c7-f43b990f7cc0
Small device:

https://github.com/user-attachments/assets/76db70fe-93cb-4502-a67b-454dc8992d73

---

### Reviewers
<!-- Tag at least 2 others for review -->
- [ ] Reviewer 1: @jonahtwalker 
- [ ] Reviewer 2: @RaghvindYadav 
- [ ] Reviewer 3: @evanschimpf  
- [ ] Reviewer 3: @shadowbrush   


### Next Steps
<!-- What needs to happen after this PR is merged? -->
- [ ] Follow-up tasks are created
  - No followup task as of now

### How to Test
<!-- Provide detailed steps for QA to test the changes -->
1. Prerequisites:
  Ensure you are signed out.
2. Test steps:
-  Visit the app: only the Welcome, Sign In, Sign Up, and Reset Password pages should be reachable.
- Try accessing any authenticated route — confirm you're redirected to Sign In.
- Observe the sidebar:
  - Only “Home” is visible.
  - Bottom section contains "Get Started" and "Sign In" buttons.
- After signing in:
  - Full sidebar content should become visible.
- Restricted routes should now be accessible.
3. Expected results:
- Sidebar and routing respect authentication state.
- Redirection to Sign In works smoothly.
- UI clearly separates authenticated vs unauthenticated experience.


## Final Checklist
- [ ] Linked related issues
- [x] Rebased with target branch
- [x] No lint errors
- [ ] QA'd in multiple browsers
- [ ] Added/updated tests (if applicable)
- [ ] Mobile responsive (if applicable)
- [ ] Updated documentation (if applicable)
- [ ] Notified the Team of this updates readiness

---

## AI Usage
<!-- Document any AI tools you used to develop this -->
- [ ] AI tools were used in development
  - **Tool used**:
    <!-- Specify any model used -->
   Augment

## References
<!-- List any helpful references used during development -->
- **Documentation**:
- **Discussions**:
- **Related PRs**:
