### PR TITLE
Es/env refactor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,21 +2,18 @@
 ### Environment
 ########################################################################################################################
 
-# ENVIRONMENT = [ production | staging | testing | development ]
-ENVIRONMENT=development
-# LOG_LEVEL = [ trace | debug | info | warn | error | fatal ]
-LOG_LEVEL=trace
-# NODE_ENV = [ production | testing | development ]
-NODE_ENV=development
-VITE_APP_ENVIRONMENT=development
+# APP_ENVIRONMENT = [ production | staging | testing | development ]
+PUBLIC_APP_ENVIRONMENT=development
+# LOG_LEVEL = [ 'debug' | 'info' | 'warn' | 'error' | 'silent' ]
+PUBLIC_LOG_LEVEL=debug
 
 ########################################################################################################################
 ### Site
 ########################################################################################################################
 
 PUBLIC_SITE_URL="http://localhost:5173"
-VITE_FSDATA_URL="http://localhost:8092/fsdata/api/graphql"
-MOCK_DATA=false
+PUBLIC_FSDATA_URL="http://localhost:8092/fsdata/api/graphql"
+PUBLIC_MOCK_DATA=false
 
 ########################################################################################################################
 ### Cloudflare

--- a/src/lib/components/layout/app-sidebar.svelte
+++ b/src/lib/components/layout/app-sidebar.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-  import { page } from '$app/state';
   import type { ComponentProps } from 'svelte';
+  import { page } from '$app/state';
+  import { env } from '$env/dynamic/public';
   import * as Sidebar from '@/components/ui/sidebar';
   import { m } from '@/paraglide/messages';
-  import { House, PlugZap, Settings, Zap } from 'lucide-svelte';
   import { Button } from '../ui/button';
+  import { House, PlugZap, Settings, Zap } from 'lucide-svelte';
 
   const items = [
     {
@@ -54,7 +55,7 @@
     return itemUrl !== '#' && currentPath.startsWith(itemUrl);
   };
 
-  const isDevEnv = $derived(import.meta.env.DEV);
+  const isDevEnv = env.PUBLIC_APP_ENVIRONMENT === 'development';
   const toggleConnection = () => {
     isOffline = !isOffline;
   };

--- a/src/lib/contexts/msa-listener-handler.svelte.ts
+++ b/src/lib/contexts/msa-listener-handler.svelte.ts
@@ -1,13 +1,13 @@
 import { env } from '$env/dynamic/public';
+import translate from '@/helpers/language/translate';
+import { m } from '@/paraglide/messages';
+import { AppUiMessage, MsaTokenStatus } from '@/types/enums';
 import {
   MultiStepActionEventType,
   type MultiStepActionProgressResult,
   type QueryResult,
   type SidMultiStepActionProgress,
 } from '@baragaun/bg-node-client';
-import translate from '@/helpers/language/translate';
-import { m } from '@/paraglide/messages';
-import { AppUiMessage, MsaTokenStatus } from '@/types/enums';
 
 let errorMessage = $state('');
 let tokenStatus = $state(MsaTokenStatus.unset);

--- a/src/lib/contexts/msa-listener-handler.svelte.ts
+++ b/src/lib/contexts/msa-listener-handler.svelte.ts
@@ -1,12 +1,13 @@
-import translate from '@/helpers/language/translate';
-import { m } from '@/paraglide/messages';
-import { AppUiMessage, MsaTokenStatus } from '@/types/enums';
+import { env } from '$env/dynamic/public';
 import {
   MultiStepActionEventType,
   type MultiStepActionProgressResult,
   type QueryResult,
   type SidMultiStepActionProgress,
 } from '@baragaun/bg-node-client';
+import translate from '@/helpers/language/translate';
+import { m } from '@/paraglide/messages';
+import { AppUiMessage, MsaTokenStatus } from '@/types/enums';
 
 let errorMessage = $state('');
 let tokenStatus = $state(MsaTokenStatus.unset);
@@ -51,7 +52,7 @@ export class MsaListenerHandler {
         ): Promise<void> => {
           if (eventType === MultiStepActionEventType.notificationFailed) {
             // The notification failed to go out.
-            if (import.meta.env.VITE_APP_ENVIRONMENT === 'development') {
+            if (env.PUBLIC_APP_ENVIRONMENT === 'development') {
               errorMessage = m['verify_token.error.dev_mode_error']();
 
               // Advance, ignoring the failure to send in development

--- a/src/lib/contexts/my-user-context.svelte.ts
+++ b/src/lib/contexts/my-user-context.svelte.ts
@@ -1,4 +1,6 @@
 import { env } from '$env/dynamic/public';
+import translate from '@/helpers/language/translate';
+import { AppUiMessage } from '@/types/enums';
 import {
   AppEnvironment,
   BgListenerTopic,
@@ -16,8 +18,6 @@ import {
   type SignInUserInput,
   type SignUpUserInput,
 } from '@baragaun/bg-node-client';
-import translate from '@/helpers/language/translate';
-import { AppUiMessage } from '@/types/enums';
 
 let isSignedIn = $state(false);
 let isOffline = $state(false); // TODO: The client does not yet support toggling the connectivity state

--- a/src/lib/contexts/my-user-context.svelte.ts
+++ b/src/lib/contexts/my-user-context.svelte.ts
@@ -1,5 +1,4 @@
-import translate from '@/helpers/language/translate';
-import { AppUiMessage } from '@/types/enums';
+import { env } from '$env/dynamic/public';
 import {
   AppEnvironment,
   BgListenerTopic,
@@ -17,6 +16,8 @@ import {
   type SignInUserInput,
   type SignUpUserInput,
 } from '@baragaun/bg-node-client';
+import translate from '@/helpers/language/translate';
+import { AppUiMessage } from '@/types/enums';
 
 let isSignedIn = $state(false);
 let isOffline = $state(false); // TODO: The client does not yet support toggling the connectivity state
@@ -38,17 +39,18 @@ export class MyUserContext {
     const config: BgNodeClientConfig = {
       inBrowser: true,
       fsdata: {
-        url: import.meta.env.VITE_FSDATA_URL || 'http://localhost:8092/fsdata/api/graphql',
+        url: env.PUBLIC_FSDATA_URL || 'http://localhost:8092/fsdata/api/graphql',
         headers: {
           [HttpHeaderName.consumer]: 'first-spark-app',
         },
       },
       clientInfoStoreType: ClientInfoStoreType.db,
-      logLevel: 'debug',
+      logLevel: env.PUBLIC_LOG_LEVEL as 'debug' | 'info' | 'warn' | 'error' | 'silent' | undefined,
+      enableGroupChannels: false,
     };
 
-    if (import.meta.env.VITE_APP_ENVIRONMENT) {
-      config.appEnvironment = import.meta.env.VITE_APP_ENVIRONMENT as AppEnvironment;
+    if (env.PUBLIC_APP_ENVIRONMENT) {
+      config.appEnvironment = env.PUBLIC_APP_ENVIRONMENT as AppEnvironment;
     }
 
     try {
@@ -91,8 +93,8 @@ export class MyUserContext {
       return;
     }
 
-    // if (import.meta.env.MOCK_DATA === 'true') {
-    //   config.useMockData = true;
+    // if (env.PUBLIC_MOCK_DATA === 'true') {
+    //    config.enableMockMode = true;
     // }
 
     this._isInitializing = false;
@@ -118,7 +120,7 @@ export class MyUserContext {
       isLoading = true;
       const input: SignUpUserInput = { email };
 
-      if (import.meta.env.VITE_APP_ENVIRONMENT === 'development') {
+      if (env.PUBLIC_APP_ENVIRONMENT === 'development') {
         input.isTestUser = true;
         input.source = '{"msaToken":"666666"}';
       }


### PR DESCRIPTION
Refactored .env file variables to use the SvelteKit `$env` modules instead of `VITE_` or `import.meta.env`.